### PR TITLE
Fix production build and resolve TypeScript errors

### DIFF
--- a/client/src/components/sections/ResearchAreas.tsx
+++ b/client/src/components/sections/ResearchAreas.tsx
@@ -83,8 +83,8 @@ export default function ResearchAreas() {
               className="bg-slate-50 rounded-xl p-6 shadow-sm transition-all hover:shadow-lg hover:-translate-y-1 duration-300 group"
               variants={item}
             >
-              <div className={`w-14 h-14 rounded-full ${colorMap[area.color].bg} flex items-center justify-center mb-6`}>
-                <FontAwesomeIcon icon={iconMap[area.icon]} className={colorMap[area.color].text} />
+              <div className={`w-14 h-14 rounded-full ${colorMap[area.color as keyof typeof colorMap].bg} flex items-center justify-center mb-6`}>
+                <FontAwesomeIcon icon={iconMap[area.icon as keyof typeof iconMap]} className={colorMap[area.color as keyof typeof colorMap].text} />
                 {/*<i className={`fas fa-${area.icon} ${colorMap[area.color].text} text-xl`}></i>*/}
               </div>
               <h3 className="font-['Space_Grotesk'] font-semibold text-xl text-slate-800 mb-3">{area.title}</h3>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "scripts": {
         "dev": "tsx server/index.ts",
-        "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+        "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
         "start": "NODE_ENV=production node dist/index.js",
         "check": "tsc",
         "db:push": "drizzle-kit push"

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,7 +59,7 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 5000
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const PORT = process.env.PORT || 3000;
+  const PORT = parseInt(process.env.PORT || "3000", 10);
   server.listen(PORT, '0.0.0.0', () => {
     log(`serving on http://0.0.0.0:${PORT}`);
   });


### PR DESCRIPTION
- Modified the `build` script in `package.json` to use `--outfile=dist/index.js` instead of `--outdir=dist`. This ensures the bundled server file is created at the location expected by the `start` script.
- Fixed TypeScript errors in `client/src/components/sections/ResearchAreas.tsx` and `server/index.ts` that were causing the production build to fail.
- In `ResearchAreas.tsx`, added type assertions to `area.color` and `area.icon` to resolve implicit 'any' type errors.
- In `server/index.ts`, used `parseInt` to ensure the `PORT` variable is a number, resolving a type mismatch in the `server.listen` function call.