### PR TITLE
fix: Refactor server to conditionally import Vite

### DIFF
--- a/client/src/components/sections/ResearchAreas.tsx
+++ b/client/src/components/sections/ResearchAreas.tsx
@@ -83,8 +83,8 @@ export default function ResearchAreas() {
               className="bg-slate-50 rounded-xl p-6 shadow-sm transition-all hover:shadow-lg hover:-translate-y-1 duration-300 group"
               variants={item}
             >
-              <div className={`w-14 h-14 rounded-full ${colorMap[area.color].bg} flex items-center justify-center mb-6`}>
-                <FontAwesomeIcon icon={iconMap[area.icon]} className={colorMap[area.color].text} />
+              <div className={`w-14 h-14 rounded-full ${colorMap[area.color as keyof typeof colorMap].bg} flex items-center justify-center mb-6`}>
+                <FontAwesomeIcon icon={iconMap[area.icon as keyof typeof iconMap]} className={colorMap[area.color as keyof typeof colorMap].text} />
                 {/*<i className={`fas fa-${area.icon} ${colorMap[area.color].text} text-xl`}></i>*/}
               </div>
               <h3 className="font-['Space_Grotesk'] font-semibold text-xl text-slate-800 mb-3">{area.title}</h3>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "scripts": {
         "dev": "tsx server/index.ts",
-        "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+        "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
         "start": "NODE_ENV=production node dist/index.js",
         "check": "tsc",
         "db:push": "drizzle-kit push"

--- a/server/dev.ts
+++ b/server/dev.ts
@@ -1,28 +1,16 @@
-import express, { type Express } from "express";
+import { type Express } from "express";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
-import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
+import { createServer as createViteServer, createLogger } from "vite";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "../vite.config.js";
 import { nanoid } from "nanoid";
 
-const viteLogger = createLogger();
-
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
-}
-
 export async function setupVite(app: Express, server: Server) {
+  const viteLogger = createLogger();
   const vite = await createViteServer({
     ...viteConfig,
     configFile: false,
@@ -36,11 +24,7 @@ export async function setupVite(app: Express, server: Server) {
     server: {
       middlewareMode: true,
       hmr: { server },
-      // You can keep allowedHosts: true if you need it,
-      // but often in dev it's not strictly necessary unless accessing
-      // the dev server from other devices on the network.
-      // If removing, ensure HMR still works as expected.
-      allowedHosts: true, // Keep it explicit
+      allowedHosts: true,
     },
     appType: "custom",
   });
@@ -57,7 +41,6 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,
@@ -69,22 +52,5 @@ export async function setupVite(app: Express, server: Server) {
       vite.ssrFixStacktrace(e as Error);
       next(e);
     }
-  });
-}
-
-export function serveStatic(app: Express) {
-  const distPath = path.resolve(__dirname, "public");
-
-  if (!fs.existsSync(distPath)) {
-    throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
-    );
-  }
-
-  app.use(express.static(distPath));
-
-  // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { serveStatic, log } from "./static";
 
 const app = express();
 app.use(express.json());
@@ -51,6 +51,7 @@ app.use((req, res, next) => {
   // setting up all the other routes so the catch-all route
   // doesn't interfere with the other routes
   if (app.get("env") === "development") {
+    const { setupVite } = await import("./dev.js");
     await setupVite(app, server);
   } else {
     serveStatic(app);
@@ -59,7 +60,7 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 5000
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const PORT = process.env.PORT || 3000;
+  const PORT = parseInt(process.env.PORT || "3000", 10);
   server.listen(PORT, '0.0.0.0', () => {
     log(`serving on http://0.0.0.0:${PORT}`);
   });

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,35 @@
+import express, { type Express } from "express";
+import fs from "fs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+
+  console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+export function serveStatic(app: Express) {
+  const distPath = path.resolve(__dirname, "public");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+
+  // fall through to index.html if the file doesn't exist
+  app.use("*", (_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}


### PR DESCRIPTION
This commit fixes a production crash (ERR_MODULE_NOT_FOUND) that occurred because the server was trying to import the `vite` package in a production environment where dev dependencies are not installed.

- Refactored the server code by separating the Vite-powered development server logic into `server/dev.ts`.
- The production static file serving logic is now in `server/static.ts`.
- The main server entry point (`server/index.ts`) now uses a dynamic `import()` to load the development server only when `NODE_ENV` is 'development'. This ensures the `vite` package is never imported in production.

Additionally, this commit includes fixes for TypeScript errors that were identified during the build process:
- Corrected the `esbuild` command in `package.json` to use `--outfile` to create a single server bundle.
- Added type assertions in `ResearchAreas.tsx` to resolve implicit 'any' type errors.
- Used `parseInt` for the server port in `server/index.ts` to ensure it's a number.