### PR TITLE
fix(start): run build before starting server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "tsx server/index.ts",
         "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-        "start": "NODE_ENV=production node dist/server/index.js",
+        "start": "npm run build && NODE_ENV=production node dist/server/index.js",
         "check": "tsc",
         "db:push": "drizzle-kit push"
     },


### PR DESCRIPTION
The `start` script was failing with a `MODULE_NOT_FOUND` error because the server code was not being built before the server was started.

This change updates the `start` script in `package.json` to run the `build` script before attempting to start the server. This ensures that the `dist` directory and its contents are created before they are needed.